### PR TITLE
Added missing dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
+    "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^1.4.0",
     "react": "^18.2.0",


### PR DESCRIPTION
This is not an issue with npm but when "bun install",  is run, "@fortawesome/fontawesome-svg-core" is not installed. This commit addresses that.
BunJS : https://bun.sh/